### PR TITLE
feat: Task 3 - 商品作成API実装

### DIFF
--- a/product_api/main.py
+++ b/product_api/main.py
@@ -1,10 +1,15 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException, status
+from product_api.models import Product, ProductCreate
+from product_api.storage import InMemoryStorage
 
 app = FastAPI(
     title="商品管理API",
     description="シンプルな商品管理システムのREST API",
     version="1.0.0"
 )
+
+# グローバルストレージインスタンス
+storage = InMemoryStorage()
 
 
 @app.get("/")
@@ -16,4 +21,19 @@ async def root():
 @app.get("/health")
 async def health_check():
     """ヘルスチェックエンドポイント"""
-    return {"status": "healthy"} 
+    return {"status": "healthy"}
+
+
+@app.post("/items", response_model=Product, status_code=status.HTTP_201_CREATED)
+async def create_product(product_data: ProductCreate) -> Product:
+    """
+    新しい商品を作成
+    
+    Args:
+        product_data: 商品作成用データ
+        
+    Returns:
+        作成された商品データ（IDと作成日時が自動設定済み）
+    """
+    created_product = storage.create_product(product_data)
+    return created_product 

--- a/tests/test_create_api.py
+++ b/tests/test_create_api.py
@@ -1,0 +1,109 @@
+import pytest
+from fastapi.testclient import TestClient
+from product_api.main import app
+
+client = TestClient(app)
+
+
+def test_create_product_with_valid_data_returns_201():
+    """正常な商品作成リクエストで201が返ることをテスト"""
+    # Arrange
+    product_data = {"name": "テスト商品", "price": 1000.0}
+    
+    # Act
+    response = client.post("/items", json=product_data)
+    
+    # Assert
+    assert response.status_code == 201
+    response_data = response.json()
+    assert response_data["id"] == 1
+    assert response_data["name"] == "テスト商品"
+    assert response_data["price"] == 1000.0
+    assert "created_at" in response_data
+
+
+def test_create_product_with_empty_name_returns_422():
+    """商品名が空の場合に422エラーが返ることをテスト"""
+    # Arrange
+    product_data = {"name": "", "price": 1000.0}
+    
+    # Act
+    response = client.post("/items", json=product_data)
+    
+    # Assert
+    assert response.status_code == 422
+    assert "detail" in response.json()
+
+
+def test_create_product_with_zero_price_returns_422():
+    """価格が0の場合に422エラーが返ることをテスト"""
+    # Arrange
+    product_data = {"name": "テスト商品", "price": 0.0}
+    
+    # Act
+    response = client.post("/items", json=product_data)
+    
+    # Assert
+    assert response.status_code == 422
+    assert "detail" in response.json()
+
+
+def test_create_product_with_negative_price_returns_422():
+    """価格が負の場合に422エラーが返ることをテスト"""
+    # Arrange
+    product_data = {"name": "テスト商品", "price": -100.0}
+    
+    # Act
+    response = client.post("/items", json=product_data)
+    
+    # Assert
+    assert response.status_code == 422
+    assert "detail" in response.json()
+
+
+def test_create_product_with_missing_name_returns_422():
+    """商品名が欠けている場合に422エラーが返ることをテスト"""
+    # Arrange
+    product_data = {"price": 1000.0}
+    
+    # Act
+    response = client.post("/items", json=product_data)
+    
+    # Assert
+    assert response.status_code == 422
+    assert "detail" in response.json()
+
+
+def test_create_product_with_missing_price_returns_422():
+    """価格が欠けている場合に422エラーが返ることをテスト"""
+    # Arrange
+    product_data = {"name": "テスト商品"}
+    
+    # Act
+    response = client.post("/items", json=product_data)
+    
+    # Assert
+    assert response.status_code == 422
+    assert "detail" in response.json()
+
+
+def test_create_multiple_products_increments_id():
+    """複数商品作成時にIDが自動採番されることをテスト"""
+    # Arrange
+    product1_data = {"name": "商品1", "price": 100.0}
+    product2_data = {"name": "商品2", "price": 200.0}
+    
+    # Act
+    response1 = client.post("/items", json=product1_data)
+    response2 = client.post("/items", json=product2_data)
+    
+    # Assert
+    assert response1.status_code == 201
+    assert response2.status_code == 201
+    
+    # IDが連続して採番されることを確認
+    # 注意: 他のテストの影響でIDが1から始まらない可能性があるため、
+    # 相対的な関係のみをテスト
+    id1 = response1.json()["id"]
+    id2 = response2.json()["id"]
+    assert id2 == id1 + 1 


### PR DESCRIPTION
## 概要
Task #3 の実装

## 関連Issue
Fixes #3

## 実装内容
- ✅ POST /items エンドポイントの実装
- ✅ リクエストバリデーション（名前必須、価格0より大きい）
- ✅ エラーハンドリング（422 Bad Request）
- ✅ 商品作成APIのテストコード（正常系・異常系）
- ✅ curlでの動作確認
- ✅ グローバルストレージインスタンス統合

## API仕様
### POST /items
- **リクエスト**: `{"name": "商品名", "price": 価格}`
- **レスポンス**: `{"id": 1, "name": "商品名", "price": 価格, "created_at": "2025-05-26T..."}`
- **ステータスコード**: 201 Created

### バリデーション
- 商品名: 必須、1文字以上
- 価格: 必須、0より大きい
- エラー時: 422 Unprocessable Entity

## テスト結果
- ✅ test_create_api.py: 7 passed
- ✅ 正常系テスト: OK
- ✅ 異常系テスト: OK
- ✅ ID自動採番: OK

## 動作確認
```bash
# 正常な商品作成
curl -X POST "http://localhost:8000/items" \
  -H "Content-Type: application/json" \
  -d '{"name": "テスト商品", "price": 1000}'\n\n# バリデーションエラー\ncurl -X POST "http://localhost:8000/items" \\\n  -H "Content-Type: application/json" \\\n  -d '{"name": "", "price": 1000}'\n```